### PR TITLE
changed redirect for vkgl to new server

### DIFF
--- a/deploy/nginx/redirect.conf
+++ b/deploy/nginx/redirect.conf
@@ -139,7 +139,7 @@ rewrite ^/capice                 https://molgenis43.gcc.rug.nl permanent;
 # DESCRIPTION:  VKGL database
 # MAINTAINER:   data-team
 # EXPIRES:      ?
-rewrite ^/vkgl                  https://molgenis122.gcc.rug.nl permanent;
+rewrite ^/vkgl                  https://vkgl.molgeniscloud.org permanent;
 
 # DESCRIPTION:  Glia Open Access Database (GOAD)
 # MAINTAINER:   Dennis Hendriksen


### PR DESCRIPTION
This is the first is a long list of changes to the redirects. The vkgl is migrated to a new server running on centos8 on the new openstack infrastructure.